### PR TITLE
Reformat all PHP files to be PSR-2 and PSR-4 compliant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.2.0]
+This version is compatible with [SimpleSAMLphp v1.17](https://simplesamlphp.org/docs/1.17/simplesamlphp-changelog)
+
+### Changed
+- Code reformatted to PSR-2
+- Declare module's class under SimpleSAML\Module namespace
+
+## [v1.1.0]
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
+
+### Changed
+- Compatible with ORCID public API v2.1
+
+## [v1.0.0]
+This version is compatible with [SimpleSAMLphp v1.14](https://simplesamlphp.org/docs/1.14/simplesamlphp-changelog)
+
+### Added
+- ORCID class
+  - Allows users to sign in with their ORCID account

--- a/README.md
+++ b/README.md
@@ -48,5 +48,13 @@ $attributemap = array(
 );
 ```
 
+## Compatibility matrix
+This table matches the module version with the supported SimpleSAMLphp version.
+| Module |  SimpleSAMLphp |
+|:------:|:--------------:|
+| v1.0.0 | v1.14          |
+| v1.1.0 | v1.14          |
+| v1.2.0 | v1.17          |
+
 ## License
 Licensed under the Apache 2.0 license, for details see `LICENSE`.

--- a/lib/Auth/Source/ORCID.php
+++ b/lib/Auth/Source/ORCID.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace SimpleSAML\Module\authorcid\Auth\Source;
+
 /**
  * Authenticate using ORCID.
  *
@@ -21,7 +23,7 @@
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
-class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
+class ORCID extends \SimpleSAML\Auth\Source {
 	
     // The string used to identify the init state.
     const STAGE_INIT = 'authorcid:init';

--- a/lib/Auth/Source/ORCID.php
+++ b/lib/Auth/Source/ORCID.php
@@ -21,11 +21,11 @@ use SimpleSAML\Utilities;
  *
  * Example authentication source configuration:
  *
- *     'orcid' => array(
+ *     'orcid' => [
  *         'authorcid:ORCID',
  *         'clientId' => 'APP-XXXXXXXXXXXXXXXX',
  *         'clientSecret' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
- *     ),
+ *     ],
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
@@ -128,34 +128,34 @@ class ORCID extends \SimpleSAML\Auth\Source
         $data = $this->_http(
             'POST',
             $this->tokenEndpoint,
-            array('Accept: application/json'),
-            array(
+            ['Accept: application/json'],
+            [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
                 'grant_type' => 'authorization_code',
                 'code' => $code,
                 'redirect_uri' => $this->redirectUri,
-            )
+            ]
         );
 
         // Add attributes
         $orcid = $data->{'orcid'};
-        $state['Attributes']['orcid.path'] = array($orcid);
+        $state['Attributes']['orcid.path'] = [$orcid];
         if (!empty($data->{'name'})) {
-            $state['Attributes']['orcid.name'] = array($data->{'name'});
+            $state['Attributes']['orcid.name'] = [$data->{'name'}];
         }
 
         // Get access token for retrieving public record
         $data = $this->_http(
             'POST',
             $this->tokenEndpoint,
-            array('Accept: application/json'),
-            array(
+            ['Accept: application/json'],
+            [
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
                 'grant_type' => 'client_credentials',
                 'scope' => '/read-public',
-            )
+            ]
         );
 
         $publicAccessToken = $data->{'access_token'};
@@ -167,21 +167,21 @@ class ORCID extends \SimpleSAML\Auth\Source
             'GET',
             $this->userInfoEndpoint . '/' . $orcid
                 . '/record/',
-            array(
+            [
                 'Accept: application/json',
                 'Authorization: Bearer ' . $publicAccessToken,
-            )
+            ]
         );
 
         if (!empty($data->{'orcid-identifier'})) {
             $orcidIdentifier = $data->{'orcid-identifier'};
             if (!empty($orcidIdentifier->{'uri'})) {
                 $state['Attributes']['orcid.uri'] =
-                    array($orcidIdentifier->{'uri'});
+                    [$orcidIdentifier->{'uri'}];
             }
             if (!empty($orcidIdentifier->{'host'})) {
                 $state['Attributes']['orcid.host'] =
-                    array($orcidIdentifier->{'host'});
+                    [$orcidIdentifier->{'host'}];
             }
         }
 
@@ -189,15 +189,15 @@ class ORCID extends \SimpleSAML\Auth\Source
             $nameData = $data->{'person'}->{'name'};
             if (!empty($nameData->{'given-names'}->{'value'})) {
                 $state['Attributes']['orcid.given-names'] =
-                    array($nameData->{'given-names'}->{'value'});
+                    [$nameData->{'given-names'}->{'value'}];
             }
             if (!empty($nameData->{'family-name'}->{'value'})) {
                 $state['Attributes']['orcid.family-name'] =
-                    array($nameData->{'family-name'}->{'value'});
+                    [$nameData->{'family-name'}->{'value'}];
             }
             if (!empty($nameData->{'credit-name'}->{'value'})) {
                 $state['Attributes']['orcid.name'] =
-                    array($nameData->{'credit-name'}->{'value'});
+                    [$nameData->{'credit-name'}->{'value'}];
             }
         }
 
@@ -206,7 +206,7 @@ class ORCID extends \SimpleSAML\Auth\Source
             foreach ($emails as $email) {
                 if (!empty($email->{'primary'}) && !empty($email->{'email'})) {
                     $state['Attributes']['orcid.email'] =
-                        array($email->{'email'});
+                        [$email->{'email'}];
                     break;
                 }
             }
@@ -214,20 +214,20 @@ class ORCID extends \SimpleSAML\Auth\Source
         Logger::debug('[authorcid] attributes=' . var_export($state['Attributes'], true));
     }
 
-    private function _http($method, $url, $headers = array(), $data = null)
+    private function _http($method, $url, $headers = [], $data = null)
     {
         Logger::debug("[authorcid] http: method="
             . var_export($method, true) . ", url=" . var_export($url, true)
             . ", headers=" . var_export($headers, true)
             . ", data=" . var_export($data, true));
         $ch = curl_init($url);
-        $opts = array(
+        $opts = [
             CURLOPT_CUSTOMREQUEST => $method,
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_CONNECTTIMEOUT => 5,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => true,
-        );
+        ];
         if (strncmp($method, 'POST', 4) === 0 && !empty($data)) {
             $opts[CURLOPT_POSTFIELDS] = http_build_query($data);
         }

--- a/www/redirect.php
+++ b/www/redirect.php
@@ -10,17 +10,17 @@ use SimpleSAML\Auth\Source;
 if (!array_key_exists('state', $_REQUEST)) {
     throw new Exception('ORCID client state information not found');
 }
-$state = State::loadState($_REQUEST['state'], sspmod_authorcid_Auth_Source_ORCID::STAGE_INIT);
+$state = State::loadState($_REQUEST['state'], SimpleSAML\Module\authorcid\Auth\Source\ORCID::STAGE_INIT);
 
 if (array_key_exists('code', $_REQUEST)) {
-    $state[sspmod_authorcid_Auth_Source_ORCID::CODE] = $_REQUEST['code'];
+    $state[SimpleSAML\Module\authorcid\Auth\Source\ORCID::CODE] = $_REQUEST['code'];
 } else {
     throw new Exception('ORCID client authorize code not returned.');;
 }
 
 // Find authentication source
-assert('array_key_exists(sspmod_authorcid_Auth_Source_ORCID::AUTHID, $state)');
-$sourceId = $state[sspmod_authorcid_Auth_Source_ORCID::AUTHID];
+assert('array_key_exists(SimpleSAML\Module\authorcid\Auth\Source\ORCID::AUTHID, $state)');
+$sourceId = $state[SimpleSAML\Module\authorcid\Auth\Source\ORCID::AUTHID];
 
 $source = Source::getById($sourceId);
 if ($source === NULL) {

--- a/www/redirect.php
+++ b/www/redirect.php
@@ -30,4 +30,3 @@ if ($source === NULL) {
 $source->finalStep($state);
 
 Source::completeAuth($state);
-

--- a/www/redirect.php
+++ b/www/redirect.php
@@ -1,5 +1,8 @@
 <?php
 
+use SimpleSAML\Auth\State;
+use SimpleSAML\Auth\Source;
+
 /**
  * Handle redirect call from ORCID.
  */
@@ -7,7 +10,7 @@
 if (!array_key_exists('state', $_REQUEST)) {
     throw new Exception('ORCID client state information not found');
 }
-$state = SimpleSAML_Auth_State::loadState($_REQUEST['state'], sspmod_authorcid_Auth_Source_ORCID::STAGE_INIT);
+$state = State::loadState($_REQUEST['state'], sspmod_authorcid_Auth_Source_ORCID::STAGE_INIT);
 
 if (array_key_exists('code', $_REQUEST)) {
     $state[sspmod_authorcid_Auth_Source_ORCID::CODE] = $_REQUEST['code'];
@@ -19,12 +22,12 @@ if (array_key_exists('code', $_REQUEST)) {
 assert('array_key_exists(sspmod_authorcid_Auth_Source_ORCID::AUTHID, $state)');
 $sourceId = $state[sspmod_authorcid_Auth_Source_ORCID::AUTHID];
 
-$source = SimpleSAML_Auth_Source::getById($sourceId);
+$source = Source::getById($sourceId);
 if ($source === NULL) {
     throw new Exception('Could not find authentication source with id ' . $sourceId);
 }
 
 $source->finalStep($state);
 
-SimpleSAML_Auth_Source::completeAuth($state);
+Source::completeAuth($state);
 


### PR DESCRIPTION
- Switch class to use namespaces
- Add use declarations to all files
- Replace sspmod_* with namespaced version
- Change coding style based on PSR-2
  - Opening braces for classes and functions go on the next line
  - Switch variable names to camelCase
  - Remove whitespaces
- Apply modern array syntax to all files