### PR TITLE
Support for ORCID Public & Member API v3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,60 +1,118 @@
 # simplesamlphp-module-authorcid
-A SimpleSAMLphp module for authenticating users' ORCID iDs and retrieving publicly-visible information from the ORCID registry.
 
-This authentication source uses the ORCID Public API to allow users to sign
-in with their ORCID username and password. Accessing the Public API requires
-a set of credentials consisting of a **Client ID** and a **Client Secret**. 
-You can configure credentials for the Public API from your personal ORCID 
-account. You can then use this authentication source to retrieve a user's 
-authenticated ORCID iD and a JSON-formatted version of their public ORCID 
-record.
+A SimpleSAMLphp authentication module for enabling users to sign in with their ORCID accounts using their registered email address and password (or alternative sign in account) and then authorise access to their ORCID iD.
 
-## User attributes
-To this end, the ORCID authentication source attempts to extract the following attributes from the user's **public** ORCID record:
- * `orcid.uri`: the full path to the ORCID record
- * `orcid.path`: just the 16 digit ORCID identifier
- * `orcid.host`: the domain of the uri, i.e. `orcid.org`
- * `orcid.name`: the user's preferred name
- * `orcid.given-names`: the user's given name, or the name they most commonly 
-    go by
- * `orcid.family-name`: the user's family name or surname
- * `orcid.email`: the user's primary email address
+This SimpleSAMLphp authentication source can be configured to use either the **Public** or **Member** ORCID API to allow users to sign in with their ORCID account. Accessing the ORCID API requires a set of client credentials consisting of a **Client ID** and a **Client Secret**.
 
-## Example authentication source configuration:
-```
-    'orcid' => array(
-        'authorcid:ORCID',
-        'clientId' => 'APP-XXXXXXXXXXXXXXXX',
-        'clientSecret' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
-    ),
+You can configure credentials for the Public API from a personal ORCID
+account. You can then use this authentication source to retrieve a user's
+authenticated ORCID iD and a JSON-formatted version of their public ORCID
+record. Member API clients have access to additional scopes to read-limited information (or write) to an ORCID record.
+
+## Installation
+
+This module requires the cURL PHP extension.
+
+### Clone repository
+
+Clone this repository into the `modules` directory of your SimpleSAMLphp
+installation as follows:
+
+```shell
+cd /path/to/simplesamlphp/modules
+git clone https://github.com/rciam/simplesamlphp-module-authorcid.git authorcid
+🍺
 ```
 
-## Example attribute mapping configuration
+## Configuration
+
+The configuration options for this authentication source are specified below:
+
+* `clientId`: REQUIRED. Your Public or Member API client id (e.g. `APP-F6TMYF419CVYMSNE`).
+* `clientSecret`: REQUIRED. Your Public or Member API client secret.
+* `authorizeEndpoint`: OPTIONAL, defaults to `https://orcid.org/oauth/authorize`. URL of ORCID's OAuth 2.0 Authorization Endpoint.
+* `tokenEndpoint`: OPTIONAL, defaults to `https://orcid.org/oauth/token`. URL of ORCID's OAuth 2.0 Token Endpoint.
+* `userInfoEndpoint`: OPTIONAL, defaults to `https://pub.orcid.org/v3.0`. Base URL of ORCID's Record API: `[userInfoEndpoint]/[orcidId]/record`.
+* `scope`: OPTIONAL, defaults to `/authenticate`. String representing the permission of access requested by the client application configured for this authentication source. Both Public and Member API client can use `/authenticate`. Member API clients have access to additional scopes to read-limited information or write to an ORCID record. Specifically:
+  * `/authenticate`: Allows the client application to obtain the record holder's 16-character ORCID iD and read public information on that ORCID record.  
+  * `/read-limited`: Allows the client application to obtain the record holder's ORCID iD and read public and limited access information on that ORCID record.
+
+The table below lists the configuration options for the production ORCID environment. Note that some settings are common to both the Public and the Member ORCID API.
+
+| Config Option        | Config Value  | Production ORCID API Version |
+| :------------------- | :------------ | :------------------- |
+| `authorizeEndpoint`  | `https://orcid.org/oauth/authorize` | Public or Member |
+| `tokenEndpoint`      | `https://orcid.org/oauth/token`     | Public or Member |
+| `userInfoEndpoint`   | 1. `https://pub.orcid.org/v3.0` <br/> 2. `https://api.orcid.org/v3.0` | 1. Public <br/> 2. Member |
+| `scope`   | 1. `/authenticate` <br/> 2. `/read-limited` | 1. Public or Member <br/> 2. Member |
+
+In addition to the production ORCID APIs, ORCID also offers a test environment, called the **Sandbox**. This allows testing client applications without accessing data in the live ORCID registry. The configuration values for testing this authentication source against the Sandbox environment are listed in the following table.
+
+| Config Option        | Config Value  | Sandbox ORCID API Version |
+| :------------------- | :------------ | :---------------- |
+| `authorizeEndpoint`  | `https://sandbox.orcid.org/oauth/authorize` | Public or Member |
+| `tokenEndpoint`      | `https://sandbox.orcid.org/oauth/token`     | Public or Member |
+| `userInfoEndpoint`   | 1. `https://pub.sandbox.orcid.org/v3.0` <br/> 2. `https://api.sandbox.orcid.org/v3.0` | - Public <br/> - Member |
+| `scope`   | 1. `/authenticate` <br/> 2. `/read-limited` | - Public or Member <br/> - Member |
+
+### Example authentication source configuration
+
+#### Public ORCID API client
+
+Adjust the configuration below according to your Public ORCID API client credentials to retrieve a user's authenticated ORCID iD and a JSON-formatted version of their public ORCID record from the production ORCID registry.
+
+```php
+'orcid' => array(
+    'authorcid:ORCID',
+    'clientId' => 'APP-XXXXXXXXXXXXXXXX',
+    'clientSecret' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+),
 ```
+
+#### Member ORCID API client
+
+Adjust the configuration below according to your Member ORCID API client credentials to retrieve a user's authenticated ORCID iD and a JSON-formatted version of their public and read-limited ORCID record from the production ORCID registry:
+
+```php
+'orcid' => array(
+    'authorcid:ORCID',
+    'clientId' => 'APP-XXXXXXXXXXXXXXXX',
+    'clientSecret' => 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+    'scope' => '/read-limited',
+    'userInfoEndpoint' => 'https://api.orcid.org/v3.0',
+),
+```
+
+### Example attribute mapping configuration
+
+Use the configuration below to update the user's attributes in the SimpleSAMLphp `$state` array based on the retrieved ORCID record data:
+
+```php
 <?php
 $attributemap = array(
-
     // Attributes returned by ORCID
-    'orcid.uri'          => 'eduPersonOrcid', // URI with a 16-digit number 
-                                              // compatible with ISO 27729, 
-                                              // a.k.a. International Standard 
-                                              // Name Identifier (ISNI)
-    'orcid.path'         => 'uid',            // The ORCID number formatted as
-                                              // xxxx-xxxx-xxxx-xxxx 
-    'orcid.name'         => 'displayName',
-    'orcid.given-names'  => 'givenName',
-    'orcid.family-name'  => 'sn',
-    'orcid.email'        => 'mail',
+    'orcid.uri'             => 'eduPersonOrcid',        // URI with a 16-digit number
+                                                        // compatible with ISO 27729,
+                                                        // a.k.a. International Standard 
+                                                        // Name Identifier (ISNI)
+    'orcid.path'            => 'uid',                   // The ORCID number formatted as
+                                                        // xxxx-xxxx-xxxx-xxxx
+    'orcid.name'            => 'displayName',           // Published name
+    'orcid.given-names'     => 'givenName',             // First name
+    'orcid.family-name'     => 'sn',                    // Last name
+    'orcid.email'           => 'mail',                  // Primary email address
+    'orcid.verified-emails' => 'voPersonVerifiedEmail', // Verified email address(es)
 );
 ```
 
 ## Compatibility matrix
 
-This table matches the module version with the supported SimpleSAMLphp version.
+The table below matches the module version with the supported SimpleSAMLphp version.
 
 | Module |  SimpleSAMLphp |
 |:------:|:--------------:|
 | v1.0   | v1.14          |
 
 ## License
+
 Licensed under the Apache 2.0 license, for details see `LICENSE`.

--- a/lib/Auth/Source/ORCID.php
+++ b/lib/Auth/Source/ORCID.php
@@ -3,13 +3,16 @@
 /**
  * Authenticate using ORCID.
  *
- * This authentication source uses the ORCID Public API to allow users to sign
- * in with their ORCID username and password. Accessing the Public API requires
- * a set of credentials consisting of a Client ID and a Client Secret. You can 
- * configure credentials for the Public API from your personal ORCID account.
- * You can then use this authentication source to retrieve a user's 
- * authenticated ORCID iD and a JSON-formatted version of their public ORCID 
- * record.
+ * This SimpleSAMLphp authentication source can be configured to use either
+ * the Public or Member ORCID API to allow users to sign in with their ORCID
+ * account. Accessing the ORCID API requires a set of client credentials
+ * consisting of a Client ID and a Client Secret.
+ *
+ * You can configure credentials for the Public API from a personal ORCID
+ * account. You can then use this authentication source to retrieve a user's
+ * authenticated ORCID iD and a JSON-formatted version of their public ORCID
+ * record. Member API clients have access to additional scopes to read-limited
+ * information (or write) to an ORCID record.
  *
  * Example authentication source configuration:
  *
@@ -21,38 +24,82 @@
  *
  * @author Nicolas Liampotis <nliam@grnet.gr>
  */
-class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
-	
-    // The string used to identify the init state.
+class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source
+{
+    /*
+     * The string used to identify the init state
+     */
     const STAGE_INIT = 'authorcid:init';
 
-    // The key of the AuthId field in the state.
+    /*
+     * The key of the AuthId field in the state
+     */
     const AUTHID = 'authorcid:AuthId';
 
-    // The key of the authZ code in the state.
+    /*
+     * The key of the authZ code in the state
+     */
     const CODE = 'authorcid:code';
 
-    // The ORCID API version
-    private $apiVersion = 'v2.1';
-
-    // The authorization endpoint
-    private $authorizeEndpoint = 'https://orcid.org/oauth/authorize';
-
-    // The token exchange endpoint
-    private $tokenEndpoint = 'https://orcid.org/oauth/token';
-
-    // The user info endpoint
-    //private $userInfoEndpoint = 'https://pub.orcid.org/v2.1'; // Public API
-    private $userInfoEndpoint = 'https://api.orcid.org/v2.1'; // Member API
-
-    // The ORCID Client redirect URI
+    /*
+     * The ORCID Client redirect URI
+     * @var string
+     */
     private $redirectURI;
 
-    // The ORCID Client application ID
+    /*
+     * The ORCID client application ID
+     * @var string
+     */
     private $clientId;
 
-    // The ORCID Client application secret
+    /*
+     * The ORCID client application secret
+     * @var string
+     */
     private $clientSecret;
+
+    /*
+     * URL of ORCID's OAuth 2.0 Authorization endpoint.
+     * Needs to match the ORCID environment:
+     * - 'https://orcid.org/oauth/authorize'         (Production)
+     * - 'https://sandbox.orcid.org/oauth/authorize' (Sandbox)
+     * @var string
+     */
+    private $authorizeEndpoint = 'https://orcid.org/oauth/authorize';
+
+    /*
+     * URL of ORCID's OAuth 2.0 Token endpoint.
+     * Needs to match the ORCID environment:
+     * - 'https://orcid.org/oauth/token'             (Production)
+     * - 'https://sandbox.orcid.org/oauth/token'     (Sandbox)
+     * @var string
+     */
+    private $tokenEndpoint = 'https://orcid.org/oauth/token';
+
+    /*
+     * Base URL of ORCID's Record API: [userInfoEndpoint]/[orcidId]/record
+     * Needs to match the ORCID API version and environment:
+     * - 'https://pub.orcid.org/v3.0'                Public API (Production)
+     * - 'https://api.orcid.org/v3.0'                Member API (Production)
+     * - 'https://pub.sandbox.orcid.org/v3.0'        Public API (Sandbox)
+     * - 'https://api.sandbox.orcid.org/v3.0'        Member API (Sandbox)
+     */
+    private $userInfoEndpoint = 'https://pub.orcid.org/v3.0';
+
+    /*
+     * The permission of access requested by the ORCID client application.
+     * For example:
+     * - '/authenticate': Allows a Public or Member client application to
+     *   obtain the record holder's 16-character ORCID iD and read public
+     *   information on that ORCID record
+     * - '/read-limited': Allows a Member client application to obtain the
+     *   record holder's ORCID iD and read public and limited access
+     *   information on that ORCID record
+     * @var string
+     */
+    private $scope = '/authenticate';
+
 
     /**
      * Constructor for this authentication source.
@@ -67,6 +114,9 @@ class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
         // Call the parent constructor first, as required by the interface
         parent::__construct($info, $config);
 
+        $this->redirectURI = SimpleSAML_Module::getModuleUrl(
+            'authorcid/redirect.php');
+
         if (!array_key_exists('clientId', $config)) {
             throw new Exception('ORCID authentication source is not properly configured: Missing clientId');
         }
@@ -77,8 +127,41 @@ class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
         }
         $this->clientSecret = $config['clientSecret'];
 
-        $this->redirectURI = SimpleSAML_Module::getModuleUrl(
-            'authorcid/redirect.php');
+        if (array_key_exists('authorizeEndpoint', $config)) {
+            if (!is_string($config['authorizeEndpoint'])) {
+                SimpleSAML_Logger::error("ORCID authentication source is not properly configured: 'authorizeEndpoint' not a string literal");
+                throw new Exception(
+                    "ORCID authentication source is not properly configured: 'authorizeEndpoint' not a string literal");
+            }
+            $this->authorizeEndpoint = $config['authorizeEndpoint'];
+        }
+
+        if (array_key_exists('tokenEndpoint', $config)) {
+            if (!is_string($config['tokenEndpoint'])) {
+                SimpleSAML_Logger::error("ORCID authentication source is not properly configured: 'tokenEndpoint' not a string literal");
+                throw new Exception(
+                    "ORCID authentication source is not properly configured: 'tokenEndpoint' not a string literal");
+            }
+            $this->tokenEndpoint = $config['tokenEndpoint'];
+        }
+
+        if (array_key_exists('userInfoEndpoint', $config)) {
+            if (!is_string($config['userInfoEndpoint'])) {
+                SimpleSAML_Logger::error("ORCID authentication source is not properly configured: 'userInfoEndpoint' not a string literal");
+                throw new Exception(
+                    "ORCID authentication source is not properly configured: 'userInfoEndpoint' not a string literal");
+            }
+            $this->userInfoEndpoint = $config['userInfoEndpoint'];
+        }
+
+        if (array_key_exists('scope', $config)) {
+            if (!is_string($config['scope'])) {
+                SimpleSAML_Logger::error("ORCID authentication source is not properly configured: 'scope' not a string literal");
+                throw new Exception(
+                    "ORCID authentication source is not properly configured: 'scope' not a string literal");
+            }
+            $this->scope = $config['scope'];
+        }
     }
 
 
@@ -99,8 +182,7 @@ class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
         $authorizeURI = $this->authorizeEndpoint
             . '?client_id=' . $this->clientId
             . '&response_type=code'
-            //. '&scope=/authenticate'
-            . '&scope=/read-limited' // Member API
+            . '&scope=' . $this->scope
             . '&show_login=true'
             . '&state=' . $stateId
             . '&redirect_uri=' . $this->redirectURI;
@@ -134,36 +216,17 @@ class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
         if (!empty($data->{'name'})) {
             $state['Attributes']['orcid.name'] = array($data->{'name'});
         }
-        //data should contain the user's access token
-        // ORCID will then return the researcher’s authenticated ORCID iD and
-        // an access token: 
-        // {"access_token":"f5af9f51-07e6-4332-8f1a-c0c11c1e3728","token_type":"bearer",
-        //"refresh_token":"f725f747-3a65-49f6-a231-3e8944ce464d","expires_in":631138518,
-        //"scope":"/read-limited","name":"Sofia Garcia","orcid":"0000-0001-2345-6789"}
+
         $accessToken = null;
         if (!empty($data->{'access_token'})) {
             $accessToken = $data->{'access_token'};
         }
-
-        // Get access token for retrieving public record
-        // TODO Check if this step is required for Public API 
-        //$data = $this->_http('POST', $this->tokenEndpoint,
-        //    array('Accept: application/json'),
-        //    array(
-        //        'client_id' => $this->clientId,
-        //        'client_secret' => $this->clientSecret,
-        //        'grant_type' => 'client_credentials',
-        //        'scope' => '/read-public',
-        //    )
-        //);
-
-        //$publicAccessToken = $data->{'access_token'};
-        SimpleSAML_Logger::debug('[authorcid] finalStep: accessToken=' 
+        SimpleSAML_Logger::debug('[authorcid] finalStep: accessToken='
             . $accessToken);
 
         // Retrieve ORCID record using access token
-        $data = $this->_http('GET', $this->userInfoEndpoint . '/' . $orcid 
-            . '/record/',
+        $data = $this->_http('GET',
+            $this->userInfoEndpoint . '/' . $orcid . '/record',
             array(
                 'Accept: application/json',
                 'Authorization: Bearer ' . $accessToken,
@@ -200,25 +263,33 @@ class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
 
         // The list of email addresses returned from the UserInfo endpoint
         $orcidEmails = [];
+        // The list of verified email addresses returned from the UserInfo
+        // endpoint
+        $verifiedOrcidEmails = [];
         // The primary email address returned from the UserInfo endpoint.
         $primaryOrcidEmail = null;
         if (!empty($data->{'person'}->{'emails'}->{'email'})) {
             $emails = $data->{'person'}->{'emails'}->{'email'};
             foreach ($emails as $email) {
                 if (!empty($email->{'email'})) {
-                    $orcidEmails[] = $email->{'email'}; 
+                    $orcidEmails[] = $email->{'email'};
+                    if (!empty($email->{'verified'})) {
+                        $verifiedOrcidEmails[] = $email->{'email'};
+                    }
                     if (!empty($email->{'primary'})) {
                         $primaryOrcidEmail = $email->{'email'};
                     }
                 }
             }
         }
-        SimpleSAML_Logger::debug('[authorcid] orcidEmails=' 
+        SimpleSAML_Logger::debug('[authorcid] orcidEmails='
             . var_export($orcidEmails, true));
-        SimpleSAML_Logger::debug('[authorcid] primaryOrcidEmail=' 
+        SimpleSAML_Logger::debug('[authorcid] verifiedOrcidEmails='
+            . var_export($verifiedOrcidEmails, true));
+        SimpleSAML_Logger::debug('[authorcid] primaryOrcidEmail='
             . var_export($primaryOrcidEmail, true));
         // If no email address in the response is marked as primary then we
-        // assume that the first returned address is the the primary one
+        // assume that the first returned address is the primary one
         if (!empty($orcidEmails)) {
             if (!empty($primaryOrcidEmail)) {
                 $state['Attributes']['orcid.email'] = array($primaryOrcidEmail);  
@@ -226,6 +297,10 @@ class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
                 $state['Attributes']['orcid.email'] = array(array_values($orcidEmails)[0]);
             }
         }
+        if (!empty($verifiedOrcidEmails)) {
+            $state['Attributes']['orcid.verified-emails'] = $verifiedOrcidEmails;
+        }
+
         SimpleSAML_Logger::debug('[authorcid] attributes=' . var_export($state['Attributes'], true));
     }
 
@@ -250,26 +325,32 @@ class sspmod_authorcid_Auth_Source_ORCID extends SimpleSAML_Auth_Source {
 
         // Send the request
         $response = curl_exec($ch);
-        $httpResponseCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        if ($httpResponseCode !== 200) {
+        // Check for HTTP error
+        if (curl_errno($ch)) {
+            $errorMsg = curl_error($ch);
+        }
+        curl_close($ch);
+
+        if (isset($errorMsg)) {
             SimpleSAML_Logger::error(
                 "[authorcid] Failed to communicate with ORCID API:"
-                . " HTTP response code: " . $httpResponseCode
-                . ", error message: '" . curl_error($ch));
-            throw new SimpleSAML_Error_Exception("Failed to communicate with ORCID API");
+                    . " HTTP Error message: '" . errorMsg);
+            throw new Exception(
+                "Failed to communicate with ORCID API:"
+                    . " HTTP Error message: '" . errorMsg);
         }
         $data = json_decode($response);
         SimpleSAML_Logger::debug("[authorcid] http: data="
             . var_export($data, true));
         assert('json_last_error()===JSON_ERROR_NONE');
-        // Check for error
+        // Check for ORCID API error
         if (isset($data->{'error-desc'})) {
             SimpleSAML_Logger::error(
                 "[authorcid] Error communicating with ORCID API:"
                     . var_export($data->{'error-desc'}, true));
-            throw new Exception('Error communicating with ORCID API');
+            throw new Exception("Error communicating with ORCID API");
         }
-        curl_close($ch);
+
         return $data;
     }
 


### PR DESCRIPTION
This PR adds support for ORCID member API v2.1. Using the member API allows reading limited-access information on an ORCID record in addition to any information made publicly available by that record's holder.

ORCID members with member API credentials can request permission from users to read limited-access data on their ORCID records through 3-legged OAuth authorization (i.e. user signs in with ORCID, grants permission, is returned to our system with an authorization code, and we exchange that code for an access token). Note: This limited-access permission is valid only for that individual’s ORCID record.

For more information refer to https://members.orcid.org/api/tutorial/read-orcid-records#readlim